### PR TITLE
検索対象をGithub Enterpriseに変更するオプション

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,12 +14,13 @@ Usage:
   ghs [OPTION] "QUERY"
 
 Application Options:
-  -s, --sort=     The sort field. 'stars', 'forks', or 'updated'. (best match)
-  -o, --order=    The sort order. 'asc' or 'desc'. (desc)
-  -l, --language= searches repositories based on the language they’re written in.
-  -u, --user=     limits searches to a specific user name.
-  -r, --repo=     limits searches to a specific repository.
-  -v, --version   print version infomation and exit.
+  -s, --sort=       The sort field. 'stars', 'forks', or 'updated'. (best match)
+  -o, --order=      The sort order. 'asc' or 'desc'. (desc)
+  -l, --language=   searches repositories based on the language they’re written in.
+  -u, --user=       limits searches to a specific user name.
+  -r, --repo=       limits searches to a specific repository.
+  -v, --version     print version infomation and exit.
+  -e, --enterprise= search from github enterprise. set the API entry point of GHE.
 
 Help Options:
   -h, --help      Show this help message

--- a/ghs.go
+++ b/ghs.go
@@ -1,6 +1,6 @@
 package main
 
-var version = "0.0.3"
+var version = "0.0.4"
 
 func main() {
 	args, opts := GhsOptionParser()
@@ -20,6 +20,6 @@ func main() {
 		query += " repo:" + opts.Repository
 	}
 
-	repos := SearchRepository(opts.Sort, opts.Order, query)
+	repos := SearchRepository(opts.Sort, opts.Order, query, opts.Enterprise)
 	PrintRepository(repos)
 }

--- a/option.go
+++ b/option.go
@@ -8,12 +8,13 @@ import (
 )
 
 type GhsOptions struct {
-	Sort       string `short:"s"  long:"sort"      description:"The sort field. 'stars', 'forks', or 'updated'." default:"best match"`
-	Order      string `short:"o"  long:"order"     description:"The sort order. 'asc' or 'desc'." default:"desc"`
-	Language   string `short:"l"  long:"language"  description:"searches repositories based on the language they’re written in."`
-	User       string `short:"u"  long:"user"      description:"limits searches to a specific user name."`
-	Repository string `short:"r"  long:"repo"      description:"limits searches to a specific repository."`
-	Version    bool   `short:"v"  long:"version"   description:"print version infomation and exit."`
+	Sort       string `short:"s"  long:"sort"       description:"The sort field. 'stars', 'forks', or 'updated'." default:"best match"`
+	Order      string `short:"o"  long:"order"      description:"The sort order. 'asc' or 'desc'." default:"desc"`
+	Language   string `short:"l"  long:"language"   description:"searches repositories based on the language they’re written in."`
+	User       string `short:"u"  long:"user"       description:"limits searches to a specific user name."`
+	Repository string `short:"r"  long:"repo"       description:"limits searches to a specific repository."`
+	Version    bool   `short:"v"  long:"version"    description:"print version infomation and exit."`
+	Enterprise string `short:"e"  long:"enterprise" description:"search from github enterprise"`
 }
 
 func GhsOptionParser() ([]string, GhsOptions) {
@@ -57,6 +58,7 @@ func printGhsOption(args []string, opts GhsOptions) {
 	debug.Printf("cmd option User = %s\n", opts.User)
 	debug.Printf("cmd option Repository = %s\n", opts.Repository)
 	debug.Printf("cmd option Version = %s\n", opts.Version)
+	debug.Printf("cmd option Enterprise = %s\n", opts.Enterprise)
 }
 
 func printGhsHelp(parser *flags.Parser) {

--- a/repository.go
+++ b/repository.go
@@ -3,15 +3,25 @@ package main
 import (
 	"fmt"
 	"github.com/google/go-github/github"
+	"net/url"
 )
 
-func SearchRepository(sort string, order string, query string) []github.Repository {
+func SearchRepository(sort string, order string, query string, enterprise string) []github.Repository {
 	client := github.NewClient(nil)
 	searchOpts := &github.SearchOptions{
 		Sort:  sort,
 		Order: order,
 		// TextMatch: true,
 		// ListOptions: github.ListOptions{Page: 1, PerPage: 1},
+	}
+
+	if enterprise != "" {
+		baseURL, err := url.Parse(enterprise)
+		if err == nil {
+			client.BaseURL = baseURL
+		} else {
+			fmt.Printf("%s cannot parse\n", enterprise)
+		}
 	}
 
 	searchResult, _, err := client.Search.Repositories(query, searchOpts)


### PR DESCRIPTION
Github EnterpriseのAPIのエントリポイントを指定して、検索するオプションを追加しました。
